### PR TITLE
Allow values from template to be overridden (removed or replaced)

### DIFF
--- a/src/models/_base.js
+++ b/src/models/_base.js
@@ -387,6 +387,9 @@ class BaseBuilder {
      let nodekey = reasoner.node(key);
      if (val === null || val === undefined) {
        delete expanded[key];
+       if (typeof expanded[key] !== 'undefined') {
+         expanded[key] = null;
+       }
      } else {
        let is_iter = is_iterable(val);
        if (nodekey.is(owl.FunctionalProperty)) {

--- a/test/test.js
+++ b/test/test.js
@@ -942,6 +942,13 @@ describe('Templates...', ()=> {
     assert(!tmpl.object);
     done();
   });
+
+  it('should allow a value to be removed or replaced', (done)=> {
+    var tmpl = as.like().actor(as.person().name('Joe')).template();
+    var like = tmpl().actor().get();
+    assert(!like.actor);
+    done();
+  });
 });
 
 describe('Extensions...', ()=> {


### PR DESCRIPTION
First, this library is super handy - thank you for writing it!

I want to be able to use an activity as a template with an option to replace values from the template, instead of just appending. The option of setting a key with an undefined value did not work, because deleting a value from a builder's expanded value map did not remove the template value from that map's prototype map. I made a change that sets a `null` value to handle this case.
