### PR TITLE
Fix `template()` losing informating when getting a template of a template

### DIFF
--- a/src/models/_base.js
+++ b/src/models/_base.js
@@ -327,7 +327,7 @@ class Base {
      }
      return ()=> {
        let bld = new Builder(type);
-       bld[_expanded] = bld[_base][_expanded] = Object.create(tmpl);
+       bld[_expanded] = bld[_base][_expanded] = Object.assign({}, tmpl);
        models.compose_builder(bld, type);
        models.compose_base(bld[_base], type);
        return bld;


### PR DESCRIPTION
Prior to this change, using `template()` would lose information in this
scenario:

1. Create an activity, `act1`
2. Get a template with `act1.template()()`, and create a new activity from the
   template, `act2`
3. Get a third template, `act2.template()()`, and use it to create `act3`.

`act3` was missing properties from `act1`.

This patch makes a change to copy properties from an activity to a template,
instead of using prototypal inheritance. This seems to fix the problem.