### PR TITLE
Force LANG=en-US for unit tests; closes #15

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "test": "mocha test/test.js"
+    "test": "LANG=en-US mocha test/test.js"
   },
   "dependencies": {
     "activitystreams-context": "^2.0.0",


### PR DESCRIPTION
There's a unit test that checks the default value for a LanguageValue item, and it assumes that the `LANG` environment variable is `en-US`. This PR forces `LANG` to `en-US` if you run `npm test`.