### PR TITLE
Update activitystreams-context and vocabs-as; closes #18

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,22 +15,22 @@
     "test": "LANG=en-US mocha test/test.js"
   },
   "dependencies": {
-    "activitystreams-context": "^2.0.0",
+    "activitystreams-context": "^3.0.0",
     "jsonld": "^0.4.11",
     "jsonld-signatures": "^1.1.5",
-    "vocabs-as": "^2.0.0",
-    "vocabs-ldp": "^0.1.0",
-    "vocabs-asx": "^0.11.1",
-    "vocabs-owl": "^0.11.1",
-    "vocabs-xsd": "^0.11.1",
-    "vocabs-rdf": "^0.11.1",
-    "vocabs-rdfs": "^0.11.1",
-    "vocabs-interval": "^0.11.1",
-    "vocabs-social": "^0.11.1",
     "moment": "^2.17.1",
     "readable-stream": "^2.2.3",
     "reasoner": "2.0.0",
-    "rfc5646": "^2.0.0"
+    "rfc5646": "^2.0.0",
+    "vocabs-as": "^3.0.0",
+    "vocabs-asx": "^0.11.1",
+    "vocabs-interval": "^0.11.1",
+    "vocabs-ldp": "^0.1.0",
+    "vocabs-owl": "^0.11.1",
+    "vocabs-rdf": "^0.11.1",
+    "vocabs-rdfs": "^0.11.1",
+    "vocabs-social": "^0.11.1",
+    "vocabs-xsd": "^0.11.1"
   },
   "devDependencies": {
     "mocha": "^3.2.0",


### PR DESCRIPTION
I used `npm install --save --no-package-lock`, which rearranges the dependencies alphabetically, so this is a bigger diff than strictly necessary but probably worth doing anyway.